### PR TITLE
Update utils.bash for ARM64 support

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -39,12 +39,17 @@ download_release() {
     Linux*) platform=linux ;;
     Darwin*) platform=macos ;;
   esac
+  
+  case "$(uname -m)" in
+    aarch64) arch=aarch64 ;;
+    x86*) arch=amd64 ;;
+  esac
 
   echo >&2 "* Downloading babashka release $version..."
 
   local ext url
   for ext in tar.gz zip; do
-    url="$GH_REPO/releases/download/v$version/babashka-$version-$platform-amd64.$ext"
+    url="$GH_REPO/releases/download/v$version/babashka-$version-$platform-$arch.$ext"
     curl "${curl_opts[@]}" -o "$filename.$ext" -C - "$url" >&/dev/null && echo $ext && return
   done
 


### PR DESCRIPTION
Hi, thanks for this plugin.

I found out that it doesn't work with ARM64 machines, so I fixed it to download proper files.