### PR TITLE
Set arm64 to amd64 until builds are availabile for native apple silicon

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -40,10 +40,14 @@ download_release() {
     Darwin*) platform=macos ;;
   esac
 
-  case "$(uname -m)" in
-    aarch64) arch=aarch64 ;;
-    x86*) arch=amd64 ;;
-  esac
+  if [ $(uname -s) == "Darwin" ] && [ $(uname -m) == "arm64" ]; then
+    arch=amd64
+  else
+    case "$(uname -m)" in
+      aarch64) arch=aarch64 ;;
+      x86*) arch=amd64 ;;
+    esac
+  fi
 
   echo >&2 "* Downloading babashka release $version..."
 


### PR DESCRIPTION
Fixes https://github.com/fredZen/asdf-babashka/issues/3 as a fix for apple silicon based Darwin machines until upstream babashka [releases](https://github.com/babashka/babashka/releases/tag/v0.8.2) native builds for Darwin on arm64. 