### PR TITLE
recognize `uname -m` returning arm64 (as it currently does on m1 mac)

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,8 +41,9 @@ download_release() {
   esac
 
   case "$(uname -m)" in
-    aarch64) arch=aarch64 ;;
+    aarch64|arm64) arch=aarch64 ;;
     x86*) arch=amd64 ;;
+    *) arch=asdf_babashka_unrecognized_arch ;;
   esac
 
   echo >&2 "* Downloading babashka release $version..."


### PR DESCRIPTION
With this change, babashka installs successfully on my m1 mac. Before the change it complains about unbound var "arch". I think this supersedes Pull request #4 and resolves issue #3 .

- the current version of apple command line tools (see below) on m1 mac returns "arm64" from `uname -m`
- update so we recognize that and download the apple silicon build from babashka releases
- also, on a failure to recognize `uname -m` output, make it clear which package (asdf-babashka) is having the problem.

- ➜  lib git:(master) ✗ pkgutil -pkg-info=com.apple.pkg.CLTools_Executables
        package-id: com.apple.pkg.CLTools_Executables version: 14.0.0.0.1.1661618636 [...]