### PR TITLE
Add clause for arm64

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,6 +41,7 @@ download_release() {
   esac
 
   case "$(uname -m)" in
+    arm64) arch=aarch64 ;;
     aarch64) arch=aarch64 ;;
     x86*) arch=amd64 ;;
   esac


### PR DESCRIPTION
Looks like apple have a different way of reporting architecture, cue eye roll. This should be enough to allow M1/2 users to install it.