### PR TITLE
Handle M1 macs

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,6 +41,7 @@ download_release() {
   esac
 
   case "$(uname -m)" in
+    arm64) arch=aarch64 ;;
     aarch64) arch=aarch64 ;;
     x86*) arch=amd64 ;;
   esac


### PR DESCRIPTION
Downloading for M1 is broken, this is just a simple fix to pull the correct package.