### PR TITLE
[macos] uname -m returns arm64 on Apple Silicon

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -41,7 +41,7 @@ download_release() {
   esac
 
   case "$(uname -m)" in
-    aarch64) arch=aarch64 ;;
+    arm64) arch=aarch64 ;;
     x86*) arch=amd64 ;;
   esac
 


### PR DESCRIPTION
`$ uname -m
arm64`

Ran this on Apple Silicon; without this, install doesn't work on M1 Macs